### PR TITLE
Bug fix from Develop branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ _ReSharper.*
 *.orig
 Thumbs.db
 .DS_Store
+.vs
 
 archive/
 src/packages/*/**

--- a/src/UmbracoArchiveProcessor/Template/MyCustomizedTemplate.cs
+++ b/src/UmbracoArchiveProcessor/Template/MyCustomizedTemplate.cs
@@ -5,8 +5,6 @@ namespace UmbracoArchiveProcessor.Template
 {
 	public class MyCustomizedTemplate<T> : TemplateBase<T>
 	{
-		public T Model { get; set; }
-
 		public MyCustomizedTemplate()
 		{
 		}


### PR DESCRIPTION
Removed the `Model` property from `MyCustomizedTemplate`,
as it was hiding `TemplateBase`'s property.
Bug from legacy code, (previously compiled against an older version of RazorEngine).
